### PR TITLE
fix: covid row id should equal row name

### DIFF
--- a/dashboards/COVID_Vaccine_Dashboard.yaml
+++ b/dashboards/COVID_Vaccine_Dashboard.yaml
@@ -226,7 +226,7 @@ position:
     - CHART-dCUpAcPsji
     - CHART-fYo7IyvKZQ
     - CHART-j4hUvP5dDD
-    id: ROW-xSeNAspgw
+    id: ROW-dieUdkeUw
     meta:
       '0': ROOT_ID
       background: BACKGROUND_TRANSPARENT


### PR DESCRIPTION
This is a port of https://github.com/apache/superset/pull/16953 to fix the COVID dashboard on Preset which had the same id/name mismatch error.