### PR TITLE
fix (Dashboard): Making Query Context Null

### DIFF
--- a/charts/Age_distribution_of_respondents_130.yaml
+++ b/charts/Age_distribution_of_respondents_130.yaml
@@ -22,8 +22,7 @@ params:
   viz_type: histogram
   x_axis_label: age
   y_axis_label: count
-query_context: '{"datasource":{"id":23,"type":"table"},"force":false,"queries":[{"time_range":"No
-  filter","granularity":"time_start","filters":[],"extras":{"time_range_endpoints":["inclusive","exclusive"],"having":"","having_druid":[],"where":""},"applied_time_extras":{},"columns":[],"metrics":[],"annotation_layers":[],"row_limit":10000,"timeseries_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"result_format":"json","result_type":"full"}'
+query_context: null
 cache_timeout: null
 uuid: 5f1ea868-604e-f69d-a241-5daa83ff33be
 version: 1.0.0

--- a/charts/Are_you_an_ethnic_minority_in_your_city_129.yaml
+++ b/charts/Are_you_an_ethnic_minority_in_your_city_129.yaml
@@ -28,9 +28,7 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: '{"datasource":{"id":23,"type":"table"},"force":false,"queries":[{"time_range":"No
-  filter","granularity":"time_start","filters":[],"extras":{"time_range_endpoints":["inclusive","exclusive"],"having":"","having_druid":[],"where":""},"applied_time_extras":{},"columns":["ethnic_minority"],"metrics":["count"],"annotation_layers":[],"row_limit":10000,"timeseries_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"result_format":"json","result_type":"full"}'
-cache_timeout: null
+query_context: null
 uuid: def07750-b5c0-0b69-6228-cb2330916166
 version: 1.0.0
 dataset_uuid: d95a2865-53ce-1f82-a53d-8e3c89331469

--- a/charts/Commute_Time_127.yaml
+++ b/charts/Commute_Time_127.yaml
@@ -40,9 +40,7 @@ params:
   treemap_ratio: 1.618033988749895
   url_params: {}
   viz_type: treemap
-query_context: '{"datasource":{"id":23,"type":"table"},"force":false,"queries":[{"time_range":"No
-  filter","granularity":"time_start","filters":[{"col":"developer_type","op":"==","val":"Currently
-  A Developer"},{"col":"communite_time","op":"!=","val":"NULL"}],"extras":{"time_range_endpoints":["inclusive","exclusive"],"having":"","having_druid":[],"where":""},"applied_time_extras":{},"columns":["communite_time"],"metrics":["count"],"annotation_layers":[],"timeseries_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"result_format":"json","result_type":"full"}'
+query_context: null
 cache_timeout: null
 uuid: 097c05c9-2dd2-481d-813d-d6c0c12b4a3d
 version: 1.0.0

--- a/charts/Country_of_Citizenship_126.yaml
+++ b/charts/Country_of_Citizenship_126.yaml
@@ -46,8 +46,7 @@ params:
   - exclusive
   url_params: {}
   viz_type: world_map
-query_context: '{"datasource":{"id":23,"type":"table"},"force":false,"queries":[{"time_range":"No
-  filter","granularity":"time_start","filters":[],"extras":{"time_range_endpoints":["inclusive","exclusive"],"having":"","having_druid":[],"where":""},"applied_time_extras":{},"columns":[],"metrics":["count",{"aggregate":"COUNT","column":{"column_name":"country_live","description":null,"expression":null,"filterable":true,"groupby":true,"id":1570,"is_dttm":false,"python_date_format":null,"type":"TEXT","verbose_name":null},"expressionType":"SIMPLE","hasCustomLabel":false,"isNew":false,"label":"COUNT(country_live)","optionName":"metric_azxwoyei39f_d7xgzshjnw6","sqlExpression":null}],"annotation_layers":[],"timeseries_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"result_format":"json","result_type":"full"}'
+query_context: null
 cache_timeout: null
 uuid: 2ba66056-a756-d6a3-aaec-0c243fb7062e
 version: 1.0.0


### PR DESCRIPTION
In Preset the FCC dashboard is bringing up a 500 error, because of its query context not being null. This is a fix for our current dashboards, in the future we are going to make it so that query context is not included in exporting a dashboard. 