### PR TITLE
Remove time range filter on New Members Chart

### DIFF
--- a/charts/New_Members_per_Month_104.yaml
+++ b/charts/New_Members_per_Month_104.yaml
@@ -40,7 +40,7 @@ params:
   start_y_axis_at_zero: true
   subheader_font_size: 0.15
   time_grain_sqla: P1M
-  time_range: Last year
+  time_range: No filter
   time_range_endpoints:
   - inclusive
   - exclusive


### PR DESCRIPTION
https://app.shortcut.com/preset/story/38092/chart-example-chart-new-members-per-month-return-no-data-because-time-range-filter-last-year-was-added