### PR TITLE
chore: update viz type to echarts_area and treemap_v2

### DIFF
--- a/charts/Games_per_Genre_115.yaml
+++ b/charts/Games_per_Genre_115.yaml
@@ -60,8 +60,7 @@ params:
     X360: '#A868B7'
     XB: '#D3B3DA'
     XOne: '#FF7F44'
-  metrics:
-  - count
+  metric: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/Games_per_Genre_115.yaml
+++ b/charts/Games_per_Genre_115.yaml
@@ -1,5 +1,5 @@
 slice_name: Games per Genre
-viz_type: treemap
+viz_type: treemap_v2
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -75,7 +75,7 @@ params:
   url_params:
     preselect_filters: '{"1389": {"platform": ["PS", "PS2", "PS3", "PS4"], "genre":
       null, "__time_range": "No filter"}}'
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: 0499bdec-0837-44f3-ae8a-8c670de81afd

--- a/charts/Members_per_Channel_107.yaml
+++ b/charts/Members_per_Channel_107.yaml
@@ -7,8 +7,7 @@ params:
   groupby:
   - channel_name
   label_colors: {}
-  metrics:
-  - count
+  metric: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/Members_per_Channel_107.yaml
+++ b/charts/Members_per_Channel_107.yaml
@@ -1,5 +1,5 @@
 slice_name: Members per Channel
-viz_type: treemap
+viz_type: treemap_v2
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -21,7 +21,7 @@ params:
   - exclusive
   treemap_ratio: 1.618033988749895
   url_params: {}
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: d44e416d-1647-44e4-b442-6da34b44adc4

--- a/charts/Messages_per_Channel_106.yaml
+++ b/charts/Messages_per_Channel_106.yaml
@@ -1,5 +1,5 @@
 slice_name: Messages per Channel
-viz_type: area
+viz_type: echarts_area
 params:
   adhoc_filters:
   - clause: WHERE
@@ -76,7 +76,7 @@ params:
   - inclusive
   - exclusive
   url_params: {}
-  viz_type: area
+  viz_type: echarts_area
   x_axis_format: smart_date
   x_axis_showminmax: true
   x_ticks_layout: auto

--- a/charts/Messages_per_Channel_106.yaml
+++ b/charts/Messages_per_Channel_106.yaml
@@ -69,6 +69,7 @@ params:
   show_controls: false
   show_legend: true
   slice_id: 2395
+  stack: Stack
   stacked_style: stream
   time_grain_sqla: P1D
   time_range: No filter

--- a/charts/Preferred_Employment_Style_97.yaml
+++ b/charts/Preferred_Employment_Style_97.yaml
@@ -26,8 +26,7 @@ params:
   groupby:
   - job_pref
   label_colors: {}
-  metrics:
-  - count
+  metric: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/Preferred_Employment_Style_97.yaml
+++ b/charts/Preferred_Employment_Style_97.yaml
@@ -1,5 +1,5 @@
 slice_name: Preferred Employment Style
-viz_type: treemap
+viz_type: treemap_v2
 params:
   adhoc_filters:
   - clause: WHERE
@@ -40,7 +40,7 @@ params:
   - exclusive
   treemap_ratio: 1.618033988749895
   url_params: {}
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: bff88053-ccc4-92f2-d6f5-de83e950e8cd

--- a/charts/Proportion_of_Revenue_by_Product_Line_96.yaml
+++ b/charts/Proportion_of_Revenue_by_Product_Line_96.yaml
@@ -1,5 +1,5 @@
 slice_name: Proportion of Revenue by Product Line
-viz_type: area
+viz_type: echarts_area
 params:
   adhoc_filters: []
   annotation_layers: []
@@ -49,7 +49,7 @@ params:
   - inclusive
   - exclusive
   url_params: {}
-  viz_type: area
+  viz_type: echarts_area
   x_axis_format: smart_date
   x_ticks_layout: auto
   y_axis_bounds:

--- a/charts/Proportion_of_Revenue_by_Product_Line_96.yaml
+++ b/charts/Proportion_of_Revenue_by_Product_Line_96.yaml
@@ -42,6 +42,7 @@ params:
   row_limit: null
   show_brush: auto
   show_legend: true
+  stack: Expand
   stacked_style: stack
   time_grain_sqla: P1M
   time_range: '2003-01-01T00:00:00 : 2005-06-01T00:00:00'

--- a/charts/Rise__Fall_of_Video_Game_Consoles_90.yaml
+++ b/charts/Rise__Fall_of_Video_Game_Consoles_90.yaml
@@ -95,6 +95,7 @@ params:
   show_brush: auto
   show_legend: false
   slice_id: 659
+  stack: Stack
   stacked_style: stream
   time_grain_sqla: null
   time_range: No filter

--- a/charts/Rise__Fall_of_Video_Game_Consoles_90.yaml
+++ b/charts/Rise__Fall_of_Video_Game_Consoles_90.yaml
@@ -1,5 +1,5 @@
 slice_name: Rise & Fall of Video Game Consoles
-viz_type: area
+viz_type: echarts_area
 params:
   adhoc_filters: []
   annotation_layers: []
@@ -104,7 +104,7 @@ params:
   url_params:
     preselect_filters: '{"1389": {"platform": ["PS", "PS2", "PS3", "PS4"], "genre":
       null, "__time_range": "No filter"}}'
-  viz_type: area
+  viz_type: echarts_area
   x_axis_format: smart_date
   x_axis_label: Year Published
   x_axis_showminmax: true

--- a/charts/Time_Spent_Commuting_127.yaml
+++ b/charts/Time_Spent_Commuting_127.yaml
@@ -1,5 +1,5 @@
 slice_name: Time Spent Commuting
-viz_type: treemap
+viz_type: treemap_v2
 params:
   adhoc_filters:
   - clause: WHERE
@@ -39,7 +39,7 @@ params:
   - exclusive
   treemap_ratio: 1.618033988749895
   url_params: {}
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: 097c05c9-2dd2-481d-813d-d6c0c12b4a3d

--- a/charts/Time_Spent_Commuting_127.yaml
+++ b/charts/Time_Spent_Commuting_127.yaml
@@ -26,8 +26,7 @@ params:
   groupby:
   - communite_time
   label_colors: {}
-  metrics:
-  - count
+  metric: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/Treemap_41.yaml
+++ b/charts/Treemap_41.yaml
@@ -1,5 +1,5 @@
 slice_name: Treemap
-viz_type: treemap
+viz_type: treemap_v2
 params:
   compare_lag: '10'
   compare_suffix: o10Y
@@ -21,7 +21,7 @@ params:
   - inclusive
   - exclusive
   until: now
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: f5858a60-39df-4260-a42e-0704beac0471

--- a/charts/Treemap_41.yaml
+++ b/charts/Treemap_41.yaml
@@ -11,8 +11,7 @@ params:
   - country_code
   limit: '25'
   markup_type: markdown
-  metrics:
-  - sum__SP_POP_TOTL
+  metric: sum__SP_POP_TOTL
   row_limit: 5000
   show_bubbles: true
   since: '1960-01-01'

--- a/charts/Vaccine_Candidates_per_Country_79.yaml
+++ b/charts/Vaccine_Candidates_per_Country_79.yaml
@@ -7,8 +7,7 @@ params:
   groupby:
   - country_name
   label_colors: {}
-  metrics:
-  - count
+  metrics: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/Vaccine_Candidates_per_Country_79.yaml
+++ b/charts/Vaccine_Candidates_per_Country_79.yaml
@@ -7,7 +7,7 @@ params:
   groupby:
   - country_name
   label_colors: {}
-  metrics: count
+  metric: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/Vaccine_Candidates_per_Country_79.yaml
+++ b/charts/Vaccine_Candidates_per_Country_79.yaml
@@ -1,5 +1,5 @@
 slice_name: Vaccine Candidates per Country
-viz_type: treemap
+viz_type: treemap_v2
 params:
   adhoc_filters: []
   color_scheme: presetColors
@@ -20,7 +20,7 @@ params:
   - exclusive
   treemap_ratio: 1.618033988749895
   url_params: {}
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: e2f5a8a7-feb0-4f79-bc6b-01fe55b98b3c

--- a/charts/Worlds_Pop_Growth_39.yaml
+++ b/charts/Worlds_Pop_Growth_39.yaml
@@ -1,5 +1,5 @@
 slice_name: World's Pop Growth
-viz_type: area
+viz_type: echarts_area
 params:
   compare_lag: '10'
   compare_suffix: o10Y
@@ -20,7 +20,7 @@ params:
   - inclusive
   - exclusive
   until: now
-  viz_type: area
+  viz_type: echarts_area
 query_context: null
 cache_timeout: null
 uuid: 48349bcc-90c0-48d9-8352-0b04e016a7fc

--- a/charts/Worlds_Pop_Growth_39.yaml
+++ b/charts/Worlds_Pop_Growth_39.yaml
@@ -15,6 +15,7 @@ params:
   row_limit: 5000
   show_bubbles: true
   since: '1960-01-01'
+  stack: Stack
   time_range: '2014-01-01 : 2014-01-02'
   time_range_endpoints:
   - inclusive

--- a/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
+++ b/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
@@ -55,7 +55,7 @@ params:
     X360: '#5AC189'
     XB: '#ACE1C4'
     XOne: '#9EE5E5'
-  metrics: count
+  metric: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
+++ b/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
@@ -55,8 +55,7 @@ params:
     X360: '#5AC189'
     XB: '#ACE1C4'
     XOne: '#9EE5E5'
-  metrics:
-  - count
+  metrics: count
   number_format: SMART_NUMBER
   queryFields:
     groupby: groupby

--- a/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
+++ b/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
@@ -1,5 +1,5 @@
 slice_name: '# of Games That Hit 100k in Sales By Release Year'
-viz_type: treemap
+viz_type: treemap_v2
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -69,7 +69,7 @@ params:
   - exclusive
   treemap_ratio: 1.618033988749895
   url_params: {}
-  viz_type: treemap
+  viz_type: treemap_v2
 query_context: null
 cache_timeout: null
 uuid: 2b69887b-23e3-b46d-d38c-8ea11856c555


### PR DESCRIPTION
treemap and area charts have been updated. Existing charts are migrated so we'll need to update this in public examples too.

Superset PRs:
* https://github.com/apache/superset/pull/20346
* https://github.com/apache/superset/pull/20359