### PR TITLE
chore: adding File_Uploads database back

### DIFF
--- a/databases/File_Uploads.yaml
+++ b/databases/File_Uploads.yaml
@@ -1,0 +1,17 @@
+database_name: File Uploads
+sqlalchemy_uri: preset://
+cache_timeout: null
+expose_in_sqllab: true
+allow_run_async: false
+allow_ctas: false
+allow_cvas: false
+allow_dml: true
+allow_csv_upload: true
+extra:
+  allows_virtual_table_explore: true
+  metadata_params: {}
+  engine_params: {}
+  schemas_allowed_for_csv_upload:
+  - main
+uuid: d21c03ce-86ec-461f-ac82-0add92a8ee07
+version: 1.0.0


### PR DESCRIPTION
We turned this feature off with https://github.com/preset-io/public-examples/pull/13, but until https://app.shortcut.com/preset/story/67836/unable-to-access-csv-upload-s3-bucket is fixed, we won't be able to merge this in.