### PR TITLE
feat: new examples DB

### DIFF
--- a/databases/Examples.yaml
+++ b/databases/Examples.yaml
@@ -1,0 +1,16 @@
+database_name: examples
+sqlalchemy_uri: examples://
+cache_timeout: null
+expose_in_sqllab: true
+allow_run_async: false
+allow_ctas: false
+allow_cvas: false
+allow_dml: false
+allow_csv_upload: false
+extra:
+  metadata_params: {}
+  engine_params: {}
+  metadata_cache_timeout: {}
+  schemas_allowed_for_csv_upload: []
+uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
+version: 1.0.0


### PR DESCRIPTION
Create the examples DB using the new dialect `examples://` from https://github.com/preset-io/superset-shell/pull/1951.

Note, before merging this we should merge https://github.com/preset-io/superset-shell/pull/1951 and make sure that new workspaces are not creating the examples DB in the old way (WIP).