### PR TITLE
fix: Updating Vehicle Sales default datetime column

### DIFF
--- a/datasets/examples/Vehicle_Sales.yaml
+++ b/datasets/examples/Vehicle_Sales.yaml
@@ -1,5 +1,5 @@
 table_name: Vehicle Sales
-main_dttm_col: OrderDate
+main_dttm_col: order_date
 description: null
 default_endpoint: null
 offset: 0


### PR DESCRIPTION
The `Vehicle Sales` dataset's default datetime column was set to `OrderDate`, which would automatically create an incorrect time range filter on charts:
![image](https://user-images.githubusercontent.com/96086495/236327773-f10aa473-a419-4cc4-943b-0f7d583693c1.png)

This PR updates the default datetime column to `order_date`:
![image](https://user-images.githubusercontent.com/96086495/236328020-868212ba-83fc-40c6-b7d6-141c18be6067.png)