### PR TITLE
Update Path_68.yaml default line width unit

### DIFF
--- a/charts/Path_68.yaml
+++ b/charts/Path_68.yaml
@@ -16,6 +16,7 @@ params:
   line_column: path_json
   line_type: json
   line_width: 150
+  line_width_unit: meters
   mapbox_style: mapbox://styles/mapbox/light-v9
   reverse_long_lat: false
   row_limit: 5000


### PR DESCRIPTION
https://github.com/apache/superset/pull/24755 adds a line width control. 

Setting the line width for this path chart to meters