### PR TITLE
fix(charts): Delete query_context from charts instead of null

### DIFF
--- a/charts/Age_distribution_of_respondents_130.yaml
+++ b/charts/Age_distribution_of_respondents_130.yaml
@@ -22,7 +22,6 @@ params:
   viz_type: histogram
   x_axis_label: age
   y_axis_label: count
-query_context: null
 cache_timeout: null
 uuid: 5f1ea868-604e-f69d-a241-5daa83ff33be
 version: 1.0.0

--- a/charts/Are_you_an_ethnic_minority_in_your_city_129.yaml
+++ b/charts/Are_you_an_ethnic_minority_in_your_city_129.yaml
@@ -28,7 +28,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 uuid: def07750-b5c0-0b69-6228-cb2330916166
 version: 1.0.0
 dataset_uuid: d95a2865-53ce-1f82-a53d-8e3c89331469

--- a/charts/Box_plot_40.yaml
+++ b/charts/Box_plot_40.yaml
@@ -23,7 +23,6 @@ params:
   viz_type: box_plot
   whisker_options: Min/max (no outliers)
   x_ticks_layout: staggered
-query_context: null
 cache_timeout: null
 uuid: 228bc8c0-0a9b-457f-839c-47df43a6c213
 version: 1.0.0

--- a/charts/Country_Growth_Rate_35.yaml
+++ b/charts/Country_Growth_Rate_35.yaml
@@ -22,7 +22,6 @@ params:
   - exclusive
   until: '2014-01-02'
   viz_type: line
-query_context: null
 cache_timeout: null
 uuid: 7126aed3-c70b-4f5c-a0c7-5aea4b32607c
 version: 1.0.0

--- a/charts/Country_of_Citizenship_126.yaml
+++ b/charts/Country_of_Citizenship_126.yaml
@@ -46,7 +46,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: world_map
-query_context: null
 cache_timeout: null
 uuid: 2ba66056-a756-d6a3-aaec-0c243fb7062e
 version: 1.0.0

--- a/charts/Cross_Channel_Relationship_125.yaml
+++ b/charts/Cross_Channel_Relationship_125.yaml
@@ -38,7 +38,6 @@ params:
   - exclusive
   viz_type: chord
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: f2a8731b-3d8c-4d86-9d33-7c0a3e64d21c
 version: 1.0.0

--- a/charts/Cross_Channel_Relationship_heatmap_124.yaml
+++ b/charts/Cross_Channel_Relationship_heatmap_124.yaml
@@ -48,7 +48,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   yscale_interval: null
-query_context: null
 cache_timeout: null
 uuid: 6cb43397-5c62-4f32-bde2-95344c412b5a
 version: 1.0.0

--- a/charts/Current_Developers_Is_this_your_first_development_job_123.yaml
+++ b/charts/Current_Developers_Is_this_your_first_development_job_123.yaml
@@ -44,7 +44,6 @@ params:
   url_params: {}
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: bfe5a8e6-146f-ef59-5e6c-13d519b236a8
 version: 1.0.0

--- a/charts/Degrees_vs_Income_122.yaml
+++ b/charts/Degrees_vs_Income_122.yaml
@@ -60,7 +60,6 @@ params:
   viz_type: box_plot
   whiskerOptions: Tukey
   x_ticks_layout: "45\xB0"
-query_context: null
 cache_timeout: null
 uuid: 02f546ae-1bf4-bd26-8bc2-14b9279c8a62
 version: 1.0.0

--- a/charts/Developer_Type_Breakdown_128.yaml
+++ b/charts/Developer_Type_Breakdown_128.yaml
@@ -28,7 +28,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: b8386be8-f44e-6535-378c-2aa2ba461286
 version: 1.0.0

--- a/charts/Ethnic_Minority__Gender_121.yaml
+++ b/charts/Ethnic_Minority__Gender_121.yaml
@@ -38,7 +38,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: sankey
-query_context: null
 cache_timeout: null
 uuid: 4880e4f4-b701-4be0-86f3-e7e89432e83b
 version: 1.0.0

--- a/charts/Filter_Segments_120.yaml
+++ b/charts/Filter_Segments_120.yaml
@@ -49,7 +49,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: filter_box
-query_context: null
 cache_timeout: null
 uuid: 6420629a-ce74-2c6b-ef7d-b2e78baa3cfe
 version: 1.0.0

--- a/charts/Filtering_Vaccines_119.yaml
+++ b/charts/Filtering_Vaccines_119.yaml
@@ -34,7 +34,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: filter_box
-query_context: null
 cache_timeout: null
 uuid: c29381ce-0e99-4cf3-bf0f-5f55d6b94176
 version: 1.0.0

--- a/charts/First_Time_Developer_118.yaml
+++ b/charts/First_Time_Developer_118.yaml
@@ -36,7 +36,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: edc75073-8f33-4123-a28d-cd6dfb33cade
 version: 1.0.0

--- a/charts/First_Time_Developer__Commute_Time_117.yaml
+++ b/charts/First_Time_Developer__Commute_Time_117.yaml
@@ -47,7 +47,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: sankey
-query_context: null
 cache_timeout: null
 uuid: 067c4a1e-ae03-4c0c-8e2a-d2c0f4bf43c3
 version: 1.0.0

--- a/charts/Flight_Path_Arcs_67.yaml
+++ b/charts/Flight_Path_Arcs_67.yaml
@@ -38,7 +38,6 @@ params:
     width: 997
     zoom: 2.929837070560775
   viz_type: deck_arc
-query_context: null
 cache_timeout: null
 uuid: 15601df9-9078-4013-956d-bd67f487157a
 version: 1.0.0

--- a/charts/Games_116.yaml
+++ b/charts/Games_116.yaml
@@ -56,7 +56,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: 2a5e562b-ab37-1b9b-1de3-1be4335c8e83
 version: 1.0.0

--- a/charts/Games_per_Genre_115.yaml
+++ b/charts/Games_per_Genre_115.yaml
@@ -75,7 +75,6 @@ params:
     preselect_filters: '{"1389": {"platform": ["PS", "PS2", "PS3", "PS4"], "genre":
       null, "__time_range": "No filter"}}'
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: 0499bdec-0837-44f3-ae8a-8c670de81afd
 version: 1.0.0

--- a/charts/Games_per_Genre_over_time_114.yaml
+++ b/charts/Games_per_Genre_over_time_114.yaml
@@ -98,7 +98,6 @@ params:
   y_axis_format: SMART_NUMBER
   y_axis_label: '# of Games Published'
   y_axis_showminmax: true
-query_context: null
 cache_timeout: null
 uuid: 0f8976aa-7bb4-40c7-860b-64445a51aaaf
 version: 1.0.0

--- a/charts/Gender_113.yaml
+++ b/charts/Gender_113.yaml
@@ -28,7 +28,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: 0f6b447c-828c-e71c-87ac-211bc412b214
 version: 1.0.0

--- a/charts/Grid_65.yaml
+++ b/charts/Grid_65.yaml
@@ -32,7 +32,6 @@ params:
     pitch: 53.470800300695146
     zoom: 12.699690845482069
   viz_type: deck_grid
-query_context: null
 cache_timeout: null
 uuid: 3d6edc6b-bae6-4dec-96d6-48f8740cf88b
 version: 1.0.0

--- a/charts/Hexagons_64.yaml
+++ b/charts/Hexagons_64.yaml
@@ -32,7 +32,6 @@ params:
     pitch: 54.08961642447763
     zoom: 13.835465702403654
   viz_type: deck_hex
-query_context: null
 cache_timeout: null
 uuid: 33fdd400-62eb-4e57-b332-de949e79a49f
 version: 1.0.0

--- a/charts/Highest_degree_held_112.yaml
+++ b/charts/Highest_degree_held_112.yaml
@@ -55,7 +55,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: 9f7d2b9c-6b3a-69f9-f03e-d3a141514639
 version: 1.0.0

--- a/charts/How_do_you_prefer_to_work_111.yaml
+++ b/charts/How_do_you_prefer_to_work_111.yaml
@@ -59,7 +59,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   yscale_interval: null
-query_context: null
 cache_timeout: null
 uuid: cb8998ab-9f93-4f0f-4e4b-3bfe4b0dea9d
 version: 1.0.0

--- a/charts/How_much_do_you_expect_to_earn_0_-_100k_110.yaml
+++ b/charts/How_much_do_you_expect_to_earn_0_-_100k_110.yaml
@@ -76,7 +76,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: histogram
-query_context: null
 cache_timeout: null
 uuid: 6d0ceb30-2008-d19c-d285-cf77dc764433
 version: 1.0.0

--- a/charts/Last_Year_Income_Distribution_109.yaml
+++ b/charts/Last_Year_Income_Distribution_109.yaml
@@ -37,7 +37,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: histogram
-query_context: null
 cache_timeout: null
 uuid: a2ec5256-94b4-43c4-b8c7-b83f70c5d4df
 version: 1.0.0

--- a/charts/Life_Expectancy_VS_Rural_37.yaml
+++ b/charts/Life_Expectancy_VS_Rural_37.yaml
@@ -44,7 +44,6 @@ params:
   viz_type: bubble
   x: sum__SP_RUR_TOTL_ZS
   y: sum__SP_DYN_LE00_IN
-query_context: null
 cache_timeout: null
 uuid: e947e868-2f65-45b0-b3d8-174da5a38c5b
 version: 1.0.0

--- a/charts/Location_of_Current_Developers_108.yaml
+++ b/charts/Location_of_Current_Developers_108.yaml
@@ -55,7 +55,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: world_map
-query_context: null
 cache_timeout: null
 uuid: 5596e0f6-78a9-465d-8325-7139c794a06a
 version: 1.0.0

--- a/charts/Members_per_Channel_107.yaml
+++ b/charts/Members_per_Channel_107.yaml
@@ -21,7 +21,6 @@ params:
   treemap_ratio: 1.618033988749895
   url_params: {}
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: d44e416d-1647-44e4-b442-6da34b44adc4
 version: 1.0.0

--- a/charts/Messages_per_Channel_106.yaml
+++ b/charts/Messages_per_Channel_106.yaml
@@ -86,7 +86,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_log_scale: false
-query_context: null
 cache_timeout: null
 uuid: b0f11bdf-793f-473f-b7d5-b9265e657896
 version: 1.0.0

--- a/charts/Most_Dominant_Platforms_105.yaml
+++ b/charts/Most_Dominant_Platforms_105.yaml
@@ -56,7 +56,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: 1810975a-f6d4-07c3-495c-c3b535d01f21
 version: 1.0.0

--- a/charts/Most_Populated_Countries_34.yaml
+++ b/charts/Most_Populated_Countries_34.yaml
@@ -21,7 +21,6 @@ params:
   - exclusive
   until: '2014-01-02'
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: 301fee78-3a6e-4740-be8d-41ab1504b46b
 version: 1.0.0

--- a/charts/New_Members_per_Month_104.yaml
+++ b/charts/New_Members_per_Month_104.yaml
@@ -47,7 +47,6 @@ params:
   url_params: {}
   viz_type: big_number
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: 92e1d712-bcf9-4d7e-9b94-26cffe502908
 version: 1.0.0

--- a/charts/Number_of_Aspiring_Developers_103.yaml
+++ b/charts/Number_of_Aspiring_Developers_103.yaml
@@ -26,7 +26,6 @@ params:
   url_params: {}
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: a0e5329f-224e-6fc8-efd2-d37d0f546ee8
 version: 1.0.0

--- a/charts/Number_of_Deals_for_each_Combination_102.yaml
+++ b/charts/Number_of_Deals_for_each_Combination_102.yaml
@@ -34,7 +34,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   yscale_interval: null
-query_context: null
 cache_timeout: null
 uuid: bd20fc69-dd51-46c1-99b5-09e37a434bf1
 version: 1.0.0

--- a/charts/Number_of_Members_100.yaml
+++ b/charts/Number_of_Members_100.yaml
@@ -17,7 +17,6 @@ params:
   url_params: {}
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: 7dad983b-e9f6-d2e8-91da-c2262d4e84e8
 version: 1.0.0

--- a/charts/Overall_Sales_By_Product_Line_99.yaml
+++ b/charts/Overall_Sales_By_Product_Line_99.yaml
@@ -48,7 +48,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: 09c497e0-f442-1121-c9e7-671e37750424
 version: 1.0.0

--- a/charts/Path_68.yaml
+++ b/charts/Path_68.yaml
@@ -39,7 +39,6 @@ params:
     width: 669
     zoom: 9.51847667620428
   viz_type: deck_path
-query_context: null
 cache_timeout: null
 uuid: 8501a452-8a3d-4234-aee2-9528835a09a3
 version: 1.0.0

--- a/charts/Polygons_66.yaml
+++ b/charts/Polygons_66.yaml
@@ -76,7 +76,6 @@ params:
     width: 667
     zoom: 11.133995608594631
   viz_type: deck_polygon
-query_context: null
 cache_timeout: null
 uuid: 169d45c9-1905-48ea-893a-2c86015dd9ae
 version: 1.0.0

--- a/charts/Popular_Genres_Across_Platforms_98.yaml
+++ b/charts/Popular_Genres_Across_Platforms_98.yaml
@@ -32,7 +32,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   yscale_interval: null
-query_context: null
 cache_timeout: null
 uuid: 326fc7e5-b7f1-448e-8a6f-80d0e7ce0b64
 version: 1.0.0

--- a/charts/Preferred_Employment_Style_97.yaml
+++ b/charts/Preferred_Employment_Style_97.yaml
@@ -40,7 +40,6 @@ params:
   treemap_ratio: 1.618033988749895
   url_params: {}
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: bff88053-ccc4-92f2-d6f5-de83e950e8cd
 version: 1.0.0

--- a/charts/Proportion_of_Revenue_by_Product_Line_96.yaml
+++ b/charts/Proportion_of_Revenue_by_Product_Line_96.yaml
@@ -57,7 +57,6 @@ params:
   - null
   - null
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: 08aff161-f60c-4cb3-a225-dc9b1140d2e3
 version: 1.0.0

--- a/charts/Publishers_With_Most_Titles_95.yaml
+++ b/charts/Publishers_With_Most_Titles_95.yaml
@@ -35,7 +35,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: d20b7324-3b80-24d4-37e2-3bd583b66713
 version: 1.0.0

--- a/charts/Quarterly_Sales_94.yaml
+++ b/charts/Quarterly_Sales_94.yaml
@@ -67,7 +67,6 @@ params:
   - null
   y_axis_format: null
   y_axis_label: Total Sales
-query_context: null
 cache_timeout: null
 uuid: 692aca26-a526-85db-c94c-411c91cc1077
 version: 1.0.0

--- a/charts/Quarterly_Sales_By_Product_Line_93.yaml
+++ b/charts/Quarterly_Sales_By_Product_Line_93.yaml
@@ -70,7 +70,6 @@ params:
   - null
   y_axis_format: null
   y_axis_label: Revenue ($)
-query_context: null
 cache_timeout: null
 uuid: db9609e4-9b78-4a32-87a7-4d9e19d51cd8
 version: 1.0.0

--- a/charts/Region_Filter_32.yaml
+++ b/charts/Region_Filter_32.yaml
@@ -32,7 +32,6 @@ params:
   - exclusive
   until: '2014-01-02'
   viz_type: filter_box
-query_context: null
 cache_timeout: null
 uuid: 48edbb9c-6c68-486b-9f56-4710e4a6a813
 version: 1.0.0

--- a/charts/Relocation_ability_92.yaml
+++ b/charts/Relocation_ability_92.yaml
@@ -36,7 +36,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: a6dd2d5a-2cdc-c8ec-f30c-85920f4f8a65
 version: 1.0.0

--- a/charts/Revenue_by_Deal_Size_91.yaml
+++ b/charts/Revenue_by_Deal_Size_91.yaml
@@ -57,7 +57,6 @@ params:
   - null
   - null
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: f065a533-2e13-42b9-bd19-801a21700dff
 version: 1.0.0

--- a/charts/Rise__Fall_of_Video_Game_Consoles_90.yaml
+++ b/charts/Rise__Fall_of_Video_Game_Consoles_90.yaml
@@ -114,7 +114,6 @@ params:
   - null
   - null
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: 83b0e2d0-d38b-d980-ed8e-e1c9846361b6
 version: 1.0.0

--- a/charts/Rural_36.yaml
+++ b/charts/Rural_36.yaml
@@ -29,7 +29,6 @@ params:
   - exclusive
   until: '2014-01-02'
   viz_type: world_map
-query_context: null
 cache_timeout: null
 uuid: d6c6b77c-e103-45d7-9280-4933e4a07c7e
 version: 1.0.0

--- a/charts/Rural_Breakdown_38.yaml
+++ b/charts/Rural_Breakdown_38.yaml
@@ -30,7 +30,6 @@ params:
   - exclusive
   until: '2011-01-02'
   viz_type: sunburst
-query_context: null
 cache_timeout: null
 uuid: 67cb721e-0b08-4131-b65e-8f8e37075e74
 version: 1.0.0

--- a/charts/Scatterplot_62.yaml
+++ b/charts/Scatterplot_62.yaml
@@ -35,7 +35,6 @@ params:
     pitch: 4.750411100577438
     zoom: 12.729132798697304
   viz_type: deck_scatter
-query_context: null
 cache_timeout: null
 uuid: 68e72304-7fba-4adb-8696-c4fe99d5db4a
 version: 1.0.0

--- a/charts/Screen_grid_63.yaml
+++ b/charts/Screen_grid_63.yaml
@@ -31,7 +31,6 @@ params:
     pitch: 4.750411100577438
     zoom: 14.161641703941438
   viz_type: deck_screengrid
-query_context: null
 cache_timeout: null
 uuid: 25c0c0c3-865d-4178-8a90-90127544cdd6
 version: 1.0.0

--- a/charts/Seasonality_of_Revenue_per_Product_Line_89.yaml
+++ b/charts/Seasonality_of_Revenue_per_Product_Line_89.yaml
@@ -40,7 +40,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: horizon
-query_context: null
 cache_timeout: null
 uuid: cf0da099-b3ab-4d94-ab62-cf353ac3c611
 version: 1.0.0

--- a/charts/Time_Spent_Commuting_127.yaml
+++ b/charts/Time_Spent_Commuting_127.yaml
@@ -39,7 +39,6 @@ params:
   treemap_ratio: 1.618033988749895
   url_params: {}
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: 097c05c9-2dd2-481d-813d-d6c0c12b4a3d
 version: 1.0.0

--- a/charts/Top_10_Games_Proportion_of_Sales_in_Markets_88.yaml
+++ b/charts/Top_10_Games_Proportion_of_Sales_in_Markets_88.yaml
@@ -113,7 +113,6 @@ params:
   viz_type: dist_bar
   x_ticks_layout: staggered
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: a40879d5-653a-42fe-9314-bbe88ad26e92
 version: 1.0.0

--- a/charts/Top_15_Languages_Spoken_at_Home_87.yaml
+++ b/charts/Top_15_Languages_Spoken_at_Home_87.yaml
@@ -37,7 +37,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: 03a74c97-52fc-cf87-233c-d4275f8c550c
 version: 1.0.0

--- a/charts/Top_Timezones_86.yaml
+++ b/charts/Top_Timezones_86.yaml
@@ -31,7 +31,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: 62b7242e-decc-2d1b-7f80-c62776939d1e
 version: 1.0.0

--- a/charts/Total_Items_Sold_85.yaml
+++ b/charts/Total_Items_Sold_85.yaml
@@ -35,7 +35,6 @@ params:
   url_params: {}
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: c3d643cd-fd6f-4659-a5b7-59402487a8d0
 version: 1.0.0

--- a/charts/Total_Items_Sold_By_Product_Line_84.yaml
+++ b/charts/Total_Items_Sold_By_Product_Line_84.yaml
@@ -46,7 +46,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
-query_context: null
 cache_timeout: null
 uuid: b8b7ca30-6291-44b0-bc64-ba42e2892b86
 version: 1.0.0

--- a/charts/Total_Revenue_83.yaml
+++ b/charts/Total_Revenue_83.yaml
@@ -36,7 +36,6 @@ params:
   url_params: {}
   viz_type: big_number_total
   y_axis_format: $,.2f
-query_context: null
 cache_timeout: null
 uuid: 7b12a243-88e0-4dc5-ac33-9a840bb0ac5a
 version: 1.0.0

--- a/charts/Total_Sales_per_Market_Grouped_by_Genre_82.yaml
+++ b/charts/Total_Sales_per_Market_Grouped_by_Genre_82.yaml
@@ -162,7 +162,6 @@ params:
   x_axis_label: Genre
   x_ticks_layout: flat
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: d8bf948e-46fd-4380-9f9c-a950c34bcc92
 version: 1.0.0

--- a/charts/Treemap_41.yaml
+++ b/charts/Treemap_41.yaml
@@ -21,7 +21,6 @@ params:
   - exclusive
   until: now
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: f5858a60-39df-4260-a42e-0704beac0471
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Approach__Stage_80.yaml
+++ b/charts/Vaccine_Candidates_per_Approach__Stage_80.yaml
@@ -32,7 +32,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   yscale_interval: null
-query_context: null
 cache_timeout: null
 uuid: 0c953c84-0c9a-418d-be9f-2894d2a2cee0
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Country_78.yaml
+++ b/charts/Vaccine_Candidates_per_Country_78.yaml
@@ -40,7 +40,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: world_map
-query_context: null
 cache_timeout: null
 uuid: ddc91df6-fb40-4826-bdca-16b85af1c024
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Country_79.yaml
+++ b/charts/Vaccine_Candidates_per_Country_79.yaml
@@ -20,7 +20,6 @@ params:
   treemap_ratio: 1.618033988749895
   url_params: {}
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: e2f5a8a7-feb0-4f79-bc6b-01fe55b98b3c
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Country__Stage_76.yaml
+++ b/charts/Vaccine_Candidates_per_Country__Stage_76.yaml
@@ -28,7 +28,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   yscale_interval: null
-query_context: null
 cache_timeout: null
 uuid: cd111331-d286-4258-9020-c7949a109ed2
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Country__Stage_77.yaml
+++ b/charts/Vaccine_Candidates_per_Country__Stage_77.yaml
@@ -21,7 +21,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: sunburst
-query_context: null
 cache_timeout: null
 uuid: f69c556f-15fe-4a82-a8bb-69d5b6954123
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Phase_74.yaml
+++ b/charts/Vaccine_Candidates_per_Phase_74.yaml
@@ -21,7 +21,6 @@ params:
   viz_type: dist_bar
   x_ticks_layout: auto
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: 392f293e-0892-4316-bd41-c927b65606a4
 version: 1.0.0

--- a/charts/Vaccine_Candidates_per_Phase_75.yaml
+++ b/charts/Vaccine_Candidates_per_Phase_75.yaml
@@ -27,7 +27,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: 30b73c65-85e7-455f-bb24-801bb0cdc670
 version: 1.0.0

--- a/charts/Vehicle_Sales_Filter_73.yaml
+++ b/charts/Vehicle_Sales_Filter_73.yaml
@@ -28,7 +28,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: filter_box
-query_context: null
 cache_timeout: null
 uuid: a5689df7-98fc-7c51-602c-ebd92dc3ec70
 version: 1.0.0

--- a/charts/Video_Game_Sales_filter_72.yaml
+++ b/charts/Video_Game_Sales_filter_72.yaml
@@ -36,7 +36,6 @@ params:
     preselect_filters: '{"1389": {"platform": ["PS", "PS2", "PS3", "PS4"], "genre":
       null, "__time_range": "No filter"}}'
   viz_type: filter_box
-query_context: null
 cache_timeout: null
 uuid: fd9ce7ec-ae08-4f71-93e0-7c26b132b2e6
 version: 1.0.0

--- a/charts/Weekly_Messages_71.yaml
+++ b/charts/Weekly_Messages_71.yaml
@@ -29,7 +29,6 @@ params:
   url_params: {}
   viz_type: big_number
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: abe2c022-ceee-a60a-e601-ab93f7ee52b1
 version: 1.0.0

--- a/charts/Weekly_Threads_70.yaml
+++ b/charts/Weekly_Threads_70.yaml
@@ -28,7 +28,6 @@ params:
   url_params: {}
   viz_type: big_number
   y_axis_format: SMART_NUMBER
-query_context: null
 cache_timeout: null
 uuid: 9f742bdd-cac1-468c-3a37-35c9b3cfd5bb
 version: 1.0.0

--- a/charts/Work_Location_Preference_69.yaml
+++ b/charts/Work_Location_Preference_69.yaml
@@ -36,7 +36,6 @@ params:
   - exclusive
   url_params: {}
   viz_type: pie
-query_context: null
 cache_timeout: null
 uuid: e6b09c28-98cf-785f-4caf-320fd4fca802
 version: 1.0.0

--- a/charts/Worlds_Pop_Growth_39.yaml
+++ b/charts/Worlds_Pop_Growth_39.yaml
@@ -22,7 +22,6 @@ params:
   - exclusive
   until: now
   viz_type: echarts_area
-query_context: null
 cache_timeout: null
 uuid: 48349bcc-90c0-48d9-8352-0b04e016a7fc
 version: 1.0.0

--- a/charts/Worlds_Population_33.yaml
+++ b/charts/Worlds_Population_33.yaml
@@ -19,7 +19,6 @@ params:
   - exclusive
   until: '2014-01-02'
   viz_type: big_number
-query_context: null
 cache_timeout: null
 uuid: 6e9c71ae-faae-4aff-8f08-e0c29e692e8c
 version: 1.0.0

--- a/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
+++ b/charts/of_Games_That_Hit_100k_in_Sales_By_Release_Year_101.yaml
@@ -69,7 +69,6 @@ params:
   treemap_ratio: 1.618033988749895
   url_params: {}
   viz_type: treemap_v2
-query_context: null
 cache_timeout: null
 uuid: 2b69887b-23e3-b46d-d38c-8ea11856c555
 version: 1.0.0


### PR DESCRIPTION
- Update query_context to not be part of the charts since the default would use "{}" and not null so when loading it with json.loads thus it doesn't break